### PR TITLE
Improves detection and removal of format characters from heading anchors

### DIFF
--- a/nGitHubTOC.js
+++ b/nGitHubTOC.js
@@ -31,7 +31,7 @@ function tocIt(inputMD, minHeading, maxHeading, ignoreLinex)
 
             headingLevel -= minHeading;
           
-            var headingAnchor = headingTitle.toLowerCase().replace(/[^_0-9a-z\xE0-\xFF- ]/g, "").replace(/_(?=.*)/g, "").replace(/\*(?=.*)/g, "").replace(/ /g, "-");
+            var headingAnchor = headingTitle.toLowerCase().replace(/[^_*0-9a-z\xE0-\xFF- ]/g, "").replace(/_{1,2}(.+?)_{1,2}/g, "$1").replace(/\*{1,3}(.+?)\*{1,3}/g, "$1").replace(/ /g, "-");
           
             if(headingAnchor in anchorTracker)
             {


### PR DESCRIPTION
fixes imthenachoman/nGitHubTOC#9
Improves condition for removal of `*` and `_` from heading anchors only if they are paired with their own kind
Pairing and syntax based on:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#styling-text